### PR TITLE
Add PMR allocation from the static buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(async_msg_handling_cpp17)
 
-set(CMAKE_CXX_STANDARD 17)
-
 set(BOOST_MIN_VER 1.71)
 find_package(Boost 1.71.0 REQUIRED system)
 find_package(Threads REQUIRED)

--- a/README.md
+++ b/README.md
@@ -42,22 +42,33 @@ t - time in seconds (default value is 10);
 m - message type in the following format (MSG_ID:MSG_SIZE_BYTES:FRACTION).
 
 # Resulting benchmarks
-## CPU:
+The measurement is done for three implementations: with a message handler
+written on CPP17, CPP14, and with an empty handler (dummy).
+The average result calculated in the following way:
+1. Gather 5 samples for each version;
+2. Exclude min and max extremums;
+3. Take the average value of the remaining 3 samples.
+
+Note: all measurements were done in the Release mode.
+
+## CPU
 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz   1.38 GHz
 
 ## Target PC
 VirtualBox Ubuntu 20.04.3 LTS
 
-## Result 1 (max package size 1500 bytes)
+## Result 1 (max package size 1200 bytes)
 Traffic_generator command options
 ```
--m 1001:64:25 -m 1002:16:25 -m 8001:1500:50 -t10
+-m 1001:64:25 -m 1002:16:25 -m 8001:1200:50 -t10
 ```
 Result (an average value of five samples in nanoseconds)
-|CPP11|CPP17|
-|:----:|:----:|
-|3056|2977|
+|CPP11|CPP17|Dummy|
+|:----:|:----:|:----:|
+|2014|1791|1711|
 
+Total performance raises formula: 1 - (cpp17-dummy)/(cpp11-dummy).
+Total performance raises: 74%.
 
 ## Result 2 (max package size 8000 bytes)
 Traffic_generator command options
@@ -66,6 +77,9 @@ Traffic_generator command options
 
 ```
 Result (an average value of five samples in nanoseconds)
-|CPP11|CPP17|
-|:----:|:----:|
-|3934|3585|
+|CPP11|CPP17|Dummy|
+|:----:|:----:|:----:|
+|3408|2586|2322|
+
+Total performance raises formula: 1 - (cpp17-dummy)/(cpp11-dummy).
+Total performance raises: 76%.

--- a/include/common_limit.hxx
+++ b/include/common_limit.hxx
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstddef>
+
+namespace limit {
+    constexpr size_t max_msg_size = 65536;
+    constexpr size_t min_header_size = 6;
+}  // namespace limit

--- a/include/messages/base_message.hxx
+++ b/include/messages/base_message.hxx
@@ -1,7 +1,13 @@
 #pragma once
 
 #include <cinttypes>
+#if __cplusplus == 201703L
 #include <cstddef>
+#else
+namespace std {
+    using byte = unsigned char;
+}
+#endif
 
 namespace msg {
 

--- a/include/messages/data_message.hxx
+++ b/include/messages/data_message.hxx
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <utility>
+#include "common_limit.hxx"
 #include "control_message.hxx"
 
 namespace msg {
 
-template <typename Container, size_t MaxSize = 65536>
+template <typename Container, size_t MaxSize = limit::max_msg_size>
 class DataMsg final : public ControlMsg<Container, MaxSize> {
 public:
     explicit DataMsg(Container&& stg):

--- a/include/network/tcp_server_connection.hxx
+++ b/include/network/tcp_server_connection.hxx
@@ -1,6 +1,12 @@
 #pragma once
 
+#if __cplusplus == 201703L
 #include <cstddef>
+#else
+namespace std {
+    using byte = unsigned char;
+}
+#endif
 #include <boost/asio.hpp>
 
 namespace net {
@@ -40,9 +46,6 @@ protected:
     std::vector<std::byte> mInputBuffer;
 
 private:
-    static constexpr size_t sInputBufferSize = 65536;
-    static constexpr size_t sMinHeaderSize = 6;
-
     void readMsgBody(size_t len);
     void readMsgIgnore(size_t len);
 

--- a/include/processor_cxx17/mem_alloc.hxx
+++ b/include/processor_cxx17/mem_alloc.hxx
@@ -1,14 +1,17 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <memory_resource>
 #include <vector>
+
+#include "common_limit.hxx"
 
 namespace mem {
 
 class MemoryResHandler final {
 public:
-    MemoryResHandler() = default;
+    MemoryResHandler();
     ~MemoryResHandler() = default;
 
     MemoryResHandler(const MemoryResHandler&) = delete;
@@ -20,6 +23,14 @@ public:
     std::pmr::vector<std::byte> getVector(const std::vector<std::byte>& buf);
 
 private:
+    // 256 kilobytes
+    static constexpr size_t sMemPool = 262144;
+    static constexpr size_t sNoOfBlksPerAlloc = 1;
+    // equals to a max msg size 65536 + 1000 bytes for internal container needs
+    static constexpr size_t sMaxBlockSize = limit::max_msg_size + 1000;
+
+    std::array<std::byte, sMemPool> mMemory;
+    std::pmr::monotonic_buffer_resource mMemRes;
     std::pmr::unsynchronized_pool_resource mMemPool;
 };
 

--- a/include/processor_cxx17/variant_visit.hxx
+++ b/include/processor_cxx17/variant_visit.hxx
@@ -20,42 +20,62 @@ struct VariantVisit final {
 
     void operator()(msg::ControlMsg<Container>& msg)
     {
-        std::cerr << "Handling Control Message."
-                  << " First byte" << std::hex
-                  << static_cast<uint8_t>(*msg.GetRawBuffer())
-                  << std::endl;
+#ifdef NDEBUG
+    static_cast<void>(msg);
+#else
+    std::cout << "Handling Control Message."
+              << " First byte" << std::hex
+              << static_cast<uint8_t>(*msg.GetRawBuffer())
+              << std::endl;
+#endif
     }
 
     void operator()(msg::ControlMsgAck<Container>& msg)
     {
-        std::cerr << "Handling Control Acknowledgement Message."
-                  << " First byte" << std::hex
-                  << static_cast<uint8_t>(*msg.GetRawBuffer())
-                  << std::endl;
+#ifdef NDEBUG
+    static_cast<void>(msg);
+#else
+    std::cout << "Handling Control Acknowledgement Message."
+              << " First byte" << std::hex
+              << static_cast<uint8_t>(*msg.GetRawBuffer())
+              << std::endl;
+#endif
     }
 
     void operator()(msg::ControlMsgNack<Container>& msg)
     {
-        std::cerr << "Handling Control Negative Acknowledgement Message."
-                  << " First byte" << std::hex
-                  << static_cast<uint8_t>(*msg.GetRawBuffer())
-                  << std::endl;
+#ifdef NDEBUG
+    static_cast<void>(msg);
+#else
+    std::cout << "Handling Control Negative Acknowledgement Message."
+              << " First byte" << std::hex
+              << static_cast<uint8_t>(*msg.GetRawBuffer())
+              << std::endl;
+#endif
     }
 
     void operator()(msg::ControlMsgAckCks<Container>& msg)
     {
-        std::cerr << "Handling Control Acknowledgement with Checksum"
-                  << " Message. First byte" << std::hex
-                  << static_cast<uint8_t>(*msg.GetRawBuffer())
-                  << std::endl;
+#ifdef NDEBUG
+    static_cast<void>(msg);
+#else
+    std::cout << "Handling Control Acknowledgement with Checksum"
+              << " Message. First byte" << std::hex
+              << static_cast<uint8_t>(*msg.GetRawBuffer())
+              << std::endl;
+#endif
     }
 
     void operator()(msg::DataMsg<Container>& msg)
     {
-        std::cerr << "Handling Data Message."
-                  << " First byte" << std::hex
-                  << static_cast<uint8_t>(*msg.GetRawBuffer())
-                  << std::endl;
+#ifdef NDEBUG
+    static_cast<void>(msg);
+#else
+    std::cout << "Handling Data Message."
+              << " First byte" << std::hex
+              << static_cast<uint8_t>(*msg.GetRawBuffer())
+              << std::endl;
+#endif
     }
 };
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${PROJECT_NAME} STATIC
     )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
+    ${MAIN_INCLUDE_DIR}
     ${NETWORK_INCLUDE_DIR}
     )
 

--- a/src/network/tcp_acceptor.cxx
+++ b/src/network/tcp_acceptor.cxx
@@ -7,6 +7,8 @@
 
 namespace net {
 
+constexpr int TcpAcceptor::sTimerDuration;
+
 TcpAcceptor::TcpAcceptor(boost::asio::io_context &io,
                          std::unique_ptr<TcpServerConnection> connection)
     : mListeningSocket(io),

--- a/src/processor_cxx11/CMakeLists.txt
+++ b/src/processor_cxx11/CMakeLists.txt
@@ -15,3 +15,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
     network
     )
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/src/processor_cxx11/msg_handler.cxx
+++ b/src/processor_cxx11/msg_handler.cxx
@@ -68,56 +68,76 @@ void MessageHandler::HandleMessage(std::unique_ptr<msg::BaseMsg> msg)
         case msg::MsgType::ControlMsg:
             {
                 auto ptr = dynamic_cast<msg::ControlMsg<Container>*>(msg.get());
+#ifdef NDEBUG
+                static_cast<void>(ptr);
+#else
                 if (ptr) {
-                    std::cerr << "Handling Control Message."
+                    std::cout << "Handling Control Message."
                               << " First byte" << std::hex
                               << static_cast<uint8_t>(*ptr->GetRawBuffer())
                               << std::endl;
                 }
+#endif
             }
             break;
         case msg::MsgType::ControlMsgAck:
             {
                 auto ptr = dynamic_cast<msg::ControlMsgAck<Container>*>(msg.get());
+#ifdef NDEBUG
+                static_cast<void>(ptr);
+#else
                 if (ptr) {
-                    std::cerr << "Handling Control Acknowledgement Message."
+                    std::cout << "Handling Control Acknowledgement Message."
                               << " First byte" << std::hex
                               << static_cast<uint8_t>(*ptr->GetRawBuffer())
                               << std::endl;
                 }
+#endif
             }
             break;
         case msg::MsgType::ControlMsgNack:
             {
                 auto ptr = dynamic_cast<msg::ControlMsgNack<Container>*>(msg.get());
+#ifdef NDEBUG
+                static_cast<void>(ptr);
+#else
                 if (ptr) {
-                    std::cerr << "Handling Control Negative Acknowledgement Message."
+                    std::cout << "Handling Control Negative Acknowledgement Message."
                               << " First byte" << std::hex
                               << static_cast<uint8_t>(*ptr->GetRawBuffer())
                               << std::endl;
                 }
+#endif
             }
             break;
         case msg::MsgType::ControlMsgAckCks:
             {
                 auto ptr = dynamic_cast<msg::ControlMsgAckCks<Container>*>(msg.get());
+#ifdef NDEBUG
+                static_cast<void>(ptr);
+#else
                 if (ptr) {
-                    std::cerr << "Handling Control Acknowledgement with Checksum Message."
+                    std::cout << "Handling Control Acknowledgement with Checksum Message."
                               << " First byte" << std::hex
                               << static_cast<uint8_t>(*ptr->GetRawBuffer())
                               << std::endl;
                 }
+#endif
             }
             break;
         case msg::MsgType::DataMsg:
             {
                 auto ptr = dynamic_cast<msg::DataMsg<Container>*>(msg.get());
+#ifdef NDEBUG
+                static_cast<void>(ptr);
+#else
                 if (ptr) {
-                    std::cerr << "Handling Data Message."
+                    std::cout << "Handling Data Message."
                               << " First byte" << std::hex
                               << static_cast<uint8_t>(*ptr->GetRawBuffer())
                               << std::endl;
                 }
+#endif
             }
             break;
         default:

--- a/src/processor_cxx17/CMakeLists.txt
+++ b/src/processor_cxx17/CMakeLists.txt
@@ -16,3 +16,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
     network
     )
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/src/processor_cxx17/mem_alloc.cxx
+++ b/src/processor_cxx17/mem_alloc.cxx
@@ -2,11 +2,16 @@
 
 namespace mem {
 
+MemoryResHandler::MemoryResHandler() :
+    mMemRes(mMemory.data(), mMemory.size()),
+    mMemPool({sNoOfBlksPerAlloc, sMaxBlockSize}, &mMemRes)
+{}
+
 std::pmr::vector<std::byte> MemoryResHandler::getVector(
         const std::vector<std::byte>& buf)
 {
-    return std::pmr::vector<std::byte>(std::begin(buf),
-            std::end(buf), &mMemPool);
+    return std::pmr::vector<std::byte>(std::begin(buf), std::end(buf),
+            &mMemPool);
 }
 
 }  // namespace mem

--- a/src/processor_dummy/CMakeLists.txt
+++ b/src/processor_dummy/CMakeLists.txt
@@ -15,3 +15,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
     network
     )
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/src/processor_dummy/msg_handler.cxx
+++ b/src/processor_dummy/msg_handler.cxx
@@ -26,8 +26,12 @@ void MessageHandler::cbReceive(const std::vector<std::byte>& data)
         return;
     }
 
+#ifdef NDEBUG
+    static_cast<void>(data);
+#else
     std::cout << "received a sequence of " << data.size() << " bytes"
         << std::endl;
+#endif
 }
 
 }  // namespace app

--- a/src/traffic_generator/CMakeLists.txt
+++ b/src/traffic_generator/CMakeLists.txt
@@ -11,3 +11,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
     Threads::Threads
     )
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
Fix CPP version build flag for different apps.
Add missing STL defines.
Add a 256kb buffer to be used by the PMR allocator.
Update README with new results.